### PR TITLE
hide setup instructions

### DIFF
--- a/src/docs/_sidebars/mainSidebar.md
+++ b/src/docs/_sidebars/mainSidebar.md
@@ -22,8 +22,8 @@
 ```
 
 ```Training & Tutorials
-# DataPLANT Setup:/docs/tutorials/DataPlant_Setup.html
 # QuickStart on ARCs:/docs/tutorials/QuickStart_arc.html
 # ARC Commander QuickStart:/docs/tutorials/QuickStart_arcCommander.html
 # Swate QuickStart:/docs/tutorials/QuickStart_swate.html
+<!-- # DataPLANT Setup:/docs/tutorials/DataPlant_Setup.html -->
 ```


### PR DESCRIPTION
As discussed yesterday. 
Hide instructions from sidebar for now. 
Still available under https://nfdi4plants.org/nfdi4plants.knowledgebase/docs/tutorials/DataPlant_Setup.html


