### PR TITLE
fix dead link

### DIFF
--- a/src/docs/tutorials/QuickStart_swate.md
+++ b/src/docs/tutorials/QuickStart_swate.md
@@ -1,0 +1,8 @@
+---
+layout: docs
+title: Swate QuickStart
+published: 2023-05-03
+add sidebar: _sidebars/mainSidebar.md
+---
+
+The site you were looking for has [moved](https://nfdi4plants.org/nfdi4plants.knowledgebase/docs/implementation/QuickStart_swate.html).


### PR DESCRIPTION
Added a mostly empty page linking to the new Quickstart source. 
Nothing I would want to do / maintain for too many resources, but this tutorial was shared a lot (e.g. ARC-on-a-stick)

https://github.com/nfdi4plants/nfdi4plants.knowledgebase/issues/110