### PR TITLE
Unify index

### DIFF
--- a/src/docs/CONTRIBUTING.md
+++ b/src/docs/CONTRIBUTING.md
@@ -9,7 +9,6 @@ article_status: published
 todo:  
 ---
 
-# Contribution Guide
 Your contribution to the DataPLANT Knowledge Base is highly appreciated.
 This guide is intended to show you how to contribute new articles and tutorials or review and adapt parts of existing ones.
 

--- a/src/docs/_sidebars/mainSidebar.md
+++ b/src/docs/_sidebars/mainSidebar.md
@@ -1,7 +1,9 @@
 ---
 ---
 
-# [Fundamentals](/index.html)
+# [Home](/docs/home.html)
+## [Contribution](/docs/CONTRIBUTING.html)
+# [Fundamentals](/docs/fundamentals/index.html)
 ## [Research Data Management](/docs/fundamentals/ResearchDataManagement.html)
 ## [FAIR Data Principles](/docs/fundamentals/FairDataPrinciples.html)
 ## [Metadata](/docs/fundamentals/Metadata.html)
@@ -13,7 +15,7 @@
 ## [Public Data Repositories](/docs/fundamentals/PublicDataRepositories.html)
 ## [Persistent Identifiers](/docs/fundamentals/PersistentIdentifiers.html)
 
-# [Implementation within DataPLANT](/docs/implementation/AnnotatedResearchContext.html)
+# [DataPLANT Implementations](/docs/implementation/index.html)
 ## [Annotated Research Context](/docs/implementation/AnnotatedResearchContext.html)
 ### [User Journey](/docs/implementation/QuickStart_arc.html)
 ## [ARC Commander](/docs/implementation/ArcCommander.html)
@@ -84,5 +86,3 @@
 ### [ARC Demo](/docs/teaching-materials/units/promotion_arc-demo/promotion_arc-demo.html)
 ## [Videos](/docs/teaching-materials/videos.html)
 ### [Start Your ARC Workshop](/docs/teaching-materials/StartYourARC.html)
-
-

--- a/src/docs/fundamentals/index.md
+++ b/src/docs/fundamentals/index.md
@@ -1,0 +1,12 @@
+---
+layout: docs
+title: Fundamentals
+published: 2023-06-01
+add toc: false
+add sidebar: _sidebars/mainSidebar.md
+add support: false
+---
+
+<br>
+
+In this section we explore **fundamental** topics on research data management (RDM). 

--- a/src/docs/implementation/index.md
+++ b/src/docs/implementation/index.md
@@ -1,0 +1,12 @@
+---
+layout: docs
+title: DataPLANT Implementations
+published: 2023-06-01
+add toc: false
+add sidebar: _sidebars/mainSidebar.md
+add support: false
+---
+
+<br>
+
+In this section we elaborate how **DataPLANT implements** aspects of RDM to support plant researchers with RDM tools and services.


### PR DESCRIPTION
- Tried to unify sub-sections and sidebar so that every sub-section (i.e. level1 # topic) links to an index.html (in that subfolder)
  - except for FAQ so far
- Added a "home" page to top of sidebar, with contribution guide as sub-page #44  