### PR TITLE
Corrected publication date of teaching-materials README.md

### DIFF
--- a/src/docs/teaching-materials/README.md
+++ b/src/docs/teaching-materials/README.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Teaching Materials
-published: 2022-12-14
+published: 2023-05-05
 ---
 
 :bulb: mostly copied here from https://github.com/nfdi4plants/teaching_materials  


### PR DESCRIPTION
Corrected the date of publication of the teaching-materials section in the respective README.md file to 05.05.2023 which was the date when setting up this section.
