### PR TITLE
Added a comment in DataHUB section on behaviour of the explore tab.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
-        "@nfdi4plants/web-components": "^1.2.1",
+        "@nfdi4plants/web-components": "^1.2.2",
         "bulma": "^0.9.2"
       },
       "devDependencies": {
@@ -40,9 +40,9 @@
       "integrity": "sha512-ukelZ49tzUqgOAEbVujl/U62JNK3wdn5kKtXVqrjKND4QvHACZOMOYaZI6/5Jd8vsg+Fq9HDwiib70FBLydOiQ=="
     },
     "node_modules/@nfdi4plants/web-components": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@nfdi4plants/web-components/-/web-components-1.2.1.tgz",
-      "integrity": "sha512-jKMe5gXcAAijP3JEI7wZjDNO4ZvNdq1B8uKwB9PrPljAWoveoBknYReaOFDTX5Xj7G1RMwi1ga8dt7uR4QWPTg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@nfdi4plants/web-components/-/web-components-1.2.2.tgz",
+      "integrity": "sha512-qVtJzDIKtN5fPnCOz8WL1DXT08X8oVvw9Uh6VHdcOKD8wQry/piJc871/zHPLSV13vtWThRdmaxwV0bbfFWS2A==",
       "dependencies": {
         "lit": "^2.0.2",
         "mermaid": "^10.1.0",
@@ -1011,9 +1011,9 @@
       "integrity": "sha512-ukelZ49tzUqgOAEbVujl/U62JNK3wdn5kKtXVqrjKND4QvHACZOMOYaZI6/5Jd8vsg+Fq9HDwiib70FBLydOiQ=="
     },
     "@nfdi4plants/web-components": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@nfdi4plants/web-components/-/web-components-1.2.1.tgz",
-      "integrity": "sha512-jKMe5gXcAAijP3JEI7wZjDNO4ZvNdq1B8uKwB9PrPljAWoveoBknYReaOFDTX5Xj7G1RMwi1ga8dt7uR4QWPTg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@nfdi4plants/web-components/-/web-components-1.2.2.tgz",
+      "integrity": "sha512-qVtJzDIKtN5fPnCOz8WL1DXT08X8oVvw9Uh6VHdcOKD8wQry/piJc871/zHPLSV13vtWThRdmaxwV0bbfFWS2A==",
       "requires": {
         "lit": "^2.0.2",
         "mermaid": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/Freymaurer/nfdi4plants-fornax-template#readme",
   "dependencies": {
-    "@nfdi4plants/web-components": "^1.2.1",
+    "@nfdi4plants/web-components": "^1.2.2",
     "bulma": "^0.9.2"
   },
   "devDependencies": {

--- a/src/docs/DataHUB-Manual/datahub-projectsPanel.md
+++ b/src/docs/DataHUB-Manual/datahub-projectsPanel.md
@@ -16,7 +16,7 @@ The projects panel lists all you ARC projects.
 <img src="./../img/datahub-projectsPanel.drawio.svg" style="width:100%;display: block;margin: 20px auto;">
 
 
-1. Choose a tab (1) to see only your ARCs, or explore other publicly available ARCs. 
+1. Choose a tab (1) to see only `Your` ARCs, or `Explore` other publicly available ARCs and all of your private and public ARCs at once.  
 2. The main panel (2) lists all ARCs
 3. Here you can also see, the visibility level (3), and 
 4. your permission or role (4) for the listed ARC. 


### PR DESCRIPTION
# Thank you for contributing to the DataPLANT Knowledge Base :rocket:

## Please make sure that

- [x] your pull request has a **good title**,
- [x] you add a short description below to summarize your changes,
- [x] the contents and images you add, are allowed to be shared publicly and - if applicable - reference the source properly,
- [x] you read the [contribution guide](https://nfdi4plants.org/nfdi4plants.knowledgebase/docs/CONTRIBUTING.html),
- [x] you tested your changes locally

If you are unsure, you can also label your PR as draft.

## Description
- In datahub-projectsPanel.md, added a clear information that under the 'Explore' tab all public ARC combined with all own ARCs are shown which includes the own private ARCs.
- Also, updated dependencies.