### PR TITLE
remove dead link prevention files

### DIFF
--- a/src/docs/SwateManual/swate_template-contribution.md
+++ b/src/docs/SwateManual/swate_template-contribution.md
@@ -1,8 +1,0 @@
----
-layout: docs
-date: 2023-06-07
-status: prevent-dead-link
-title: Sorry, this site moved...
----
-
-The site you are looking for was moved [here](./../guides/index.html).

--- a/src/docs/implementation/AnnotationPatterns.md
+++ b/src/docs/implementation/AnnotationPatterns.md
@@ -1,8 +1,0 @@
----
-layout: docs
-date: 2023-06-07
-status: prevent-dead-link
-title: Sorry, this site moved...
----
-
-The site you are looking for was moved [here](./../guides/index.html).

--- a/src/docs/implementation/QuickStart_arc.md
+++ b/src/docs/implementation/QuickStart_arc.md
@@ -1,8 +1,0 @@
----
-layout: docs
-date: 2023-06-07
-status: prevent-dead-link
-title: Sorry, this site moved...
----
-
-The site you are looking for was moved [here](./../guides/index.html).

--- a/src/docs/implementation/QuickStart_arcCommander.md
+++ b/src/docs/implementation/QuickStart_arcCommander.md
@@ -1,8 +1,0 @@
----
-layout: docs
-date: 2023-06-07
-status: prevent-dead-link
-title: Sorry, this site moved...
----
-
-The site you are looking for was moved [here](./../guides/index.html).

--- a/src/docs/implementation/QuickStart_arcCommander_expert.md
+++ b/src/docs/implementation/QuickStart_arcCommander_expert.md
@@ -1,8 +1,0 @@
----
-layout: docs
-date: 2023-06-07
-status: prevent-dead-link
-title: Sorry, this site moved...
----
-
-The site you are looking for was moved [here](./../guides/index.html).

--- a/src/docs/implementation/QuickStart_swate.md
+++ b/src/docs/implementation/QuickStart_swate.md
@@ -1,8 +1,0 @@
----
-layout: docs
-date: 2023-06-07
-status: prevent-dead-link
-title: Sorry, this site moved...
----
-
-The site you are looking for was moved [here](./../guides/index.html).

--- a/src/docs/implementation/QuickStart_swate_walkthrough.md
+++ b/src/docs/implementation/QuickStart_swate_walkthrough.md
@@ -1,8 +1,0 @@
----
-layout: docs
-date: 2023-06-07
-status: prevent-dead-link
-title: Sorry, this site moved...
----
-
-The site you are looking for was moved [here](./../guides/index.html).


### PR DESCRIPTION
- removed pages that would re-route users to new location of sites
- after half a year these links are likely not relevant anymore; all info persists and can be found via search