### PR TITLE
ARCCommander: replace deprecated "arc i create" in quickstart documentation

### DIFF
--- a/src/docs/guides/arcCommander_QuickStart.md
+++ b/src/docs/guides/arcCommander_QuickStart.md
@@ -55,10 +55,12 @@ arc init
 
 ### ISA investigation
 
-The ISA investigation (`-i`) workbook allows you to record administrative metadata of your project. Add the isa.investigation.xlsx workbook including an identifier to your ARC with
+The ISA investigation (`-i`) workbook allows you to record administrative metadata of your project.
+The isa.investigation.xlsx workbook including an identifier to your ARC has been added to the project during initialization.
+You can update the identifier of your ARC with
 
 ```bash
-arc investigation create -i QuickStartInvestigation
+arc investigation update -i QuickStartInvestigation
 ```
 > :bulb: Avoid using spaces in the identifier. Use underscores and capital letters instead.
 

--- a/src/docs/guides/arcCommander_QuickStart_expert.md
+++ b/src/docs/guides/arcCommander_QuickStart_expert.md
@@ -42,8 +42,7 @@ mkdir <path/to/YourARCFolder>
 cd <path/to/YourARCFolder>
 
 # Setup the ARC structure with one study and one assay
-arc init
-arc investigation create -i <YourInvestigationID>
+arc init -i <YourInvestigationID>
 arc assay add -s <YourStudyID> -a <YourAssayID>
 
 arc sync -f -r https://git.nfdi4plants.org/<YourUserName>/<YourARC> -m "initialize ARC structure"


### PR DESCRIPTION
# Thank you for contributing to the DataPLANT Knowledge Base :rocket:

## Please make sure that

- [x] your pull request has a **good title**,
- [x] you add a short description below to summarize your changes,
- [x] the contents and images you add, are allowed to be shared publicly and - if applicable - reference the source properly,
- [x] you read the [contribution guide](https://nfdi4plants.org/nfdi4plants.knowledgebase/docs/CONTRIBUTING.html),
- [x] you tested your changes locally

If you are unsure, you can also label your PR as draft.

## Description
The quick start documentation references the command `arc investigation create -i <ID>`. However, this feature seems to be deprecated in favor of arc init running this step automatically. This PR updates the quick start guide to reflect that.
