### PR TITLE
Change examples to not only use `Directory` for outputs

### DIFF
--- a/src/docs/guides/ComputationalWorkflows/cwl_examples.md
+++ b/src/docs/guides/ComputationalWorkflows/cwl_examples.md
@@ -38,12 +38,26 @@ inputs:
       # prefix is optional
       prefix: -i
 outputs:
-  myOutput:
+  myFileOutput:
+	type: File
+	outputBinding:
+      # this returns a specific file
+	  glob: myOutput.txt
+  myFileArrayOutput:
+    type: File[]
+    outputBinding:
+	  # this returns all files with the extension .txt
+	  glob: $(runtime.outdir)/*.txt
+  myDirectoryOutput:
     type: Directory
     outputBinding:
-      # this returns the whole working directory
-      glob: $(runtime.outdir)
+      # this returns a specific directory
+      glob: $(runtime.outdir)/myDirectory
 ```
+
+There are several possibilities to retrieve the output of a tool. Common options would be `File`, `File[]`, or `Directory`. 
+For usage in workflows and provenance tracking, it is recommended to use `File` as the output type. This way, several output files can be 
+specified and used in the following workflow steps.
 
 ### With a docker container
 
@@ -73,12 +87,26 @@ inputs:
       # prefix is optional
       prefix: -i
 outputs:
-  myOutput:
+  myFileOutput:
+	type: File
+	outputBinding:
+      # this returns a specific file
+	  glob: myOutput.txt
+  myFileArrayOutput:
+    type: File[]
+    outputBinding:
+	  # this returns all files with the extension .txt
+	  glob: $(runtime.outdir)/*.txt
+  myDirectoryOutput:
     type: Directory
     outputBinding:
-      # this returns the whole working directory
-      glob: $(runtime.outdir)
+      # this returns a specific directory
+      glob: $(runtime.outdir)/myDirectory
 ```
+
+There are several possibilities to retrieve the output of a tool. Common options would be `File`, `File[]`, or `Directory`. 
+For usage in workflows and provenance tracking, it is recommended to use `File` as the output type. This way, several output files can be 
+specified and used in the following workflow steps.
 
 ### With a fixed script file
 
@@ -249,9 +277,9 @@ steps:
     out: [myOutput2]
 outputs:
   outputTool1:
-    type: Directory
+    type: File
     outputSource: myTool1/myOutput1
-  outputTool1:
+  outputTool2:
     type: Directory
     outputSource: myTool2/myOutput2
 ```

--- a/src/docs/guides/ComputationalWorkflows/cwl_examples.md
+++ b/src/docs/guides/ComputationalWorkflows/cwl_examples.md
@@ -56,7 +56,9 @@ outputs:
 ```
 
 There are several possibilities to retrieve the output of a tool. Common options would be `File`, `File[]`, or `Directory`. 
-For usage in workflows and provenance tracking, it is recommended to use `File` as the output type. This way, several output files can be 
+Depending on your tool or script, the output varies. If your tool returns a fixed number of known files, you should specify them as `File`. If it has a variable number of 
+files with a known extension, you should specify them as `File[]`. If it has a variable output structure, you should specify it as `Directory`.
+For usage in workflows and provenance tracking, if your tool or script allows it, it is recommended to use `File` as the output type. This way, several output files can be 
 specified and used in the following workflow steps.
 
 ### With a docker container
@@ -105,7 +107,9 @@ outputs:
 ```
 
 There are several possibilities to retrieve the output of a tool. Common options would be `File`, `File[]`, or `Directory`. 
-For usage in workflows and provenance tracking, it is recommended to use `File` as the output type. This way, several output files can be 
+Depending on your tool or script, the output varies. If your tool returns a fixed number of known files, you should specify them as `File`. If it has a variable number of 
+files with a known extension, you should specify them as `File[]`. If it has a variable output structure, you should specify it as `Directory`.
+For usage in workflows and provenance tracking, if your tool or script allows it, it is recommended to use `File` as the output type. This way, several output files can be 
 specified and used in the following workflow steps.
 
 ### With a fixed script file

--- a/src/docs/guides/ComputationalWorkflows/cwl_examples.md
+++ b/src/docs/guides/ComputationalWorkflows/cwl_examples.md
@@ -143,10 +143,10 @@ inputs:
       prefix: -i
 outputs:
   myOutput:
-    type: Directory
+    type: File
     outputBinding:
-      # this returns the whole working directory
-      glob: $(runtime.outdir)
+      glob: "result.csv"
+
 ```
 [Example](https://git.nfdi4plants.org/muehlhaus/ArcPrototype/-/tree/main/workflows/FixedScript)
 
@@ -188,9 +188,9 @@ inputs:
       prefix: -i
 outputs:
   myOutput:
-    type: Directory
+    type: File
     outputBinding:
-      glob: "./arc/runs/myRun"
+      glob: "./arc/runs/myRun/result.csv"
 ```
 
 [Example](https://git.nfdi4plants.org/muehlhaus/ArcPrototype/-/tree/main/workflows/ARCMount)
@@ -234,9 +234,9 @@ inputs:
       prefix: -i
 outputs:
   myOutput:
-    type: Directory
+    type: File
     outputBinding:
-      glob: "./arc/runs/myRun"
+      glob: "./arc/runs/myRun/result.csv"
 ```
 The Dockerfile should only include operations that reference resources that are available online or within the baseimage. COPY operations that point to local files for 
 example won't work in the context of CWL. If they are necessary for the execution in the devcontainer context (e.g. configuration for editors), but not the execution of the script, they 


### PR DESCRIPTION
This PR changes the CWL examples to show `File` and `File[]` as output options, and recommend them. It also adapts the FixedScript, ARCMount, and Devcontainer examples to their linked examples. It addresses part of #423