### PR TITLE
Fix links in arcmanager manual

### DIFF
--- a/src/docs/ARCmanager-manual/00_index.md
+++ b/src/docs/ARCmanager-manual/00_index.md
@@ -17,13 +17,13 @@ Here, you can find detailed information about using the ARCmanager web service.
 
 Contents:
 
-- [What is the ARCmanager?](/docs/ARCmanager-manual/01_intro.html)
-- [Connect to your DataHUB](/docs/ARCmanager-manual/02_login.html)
-- [View ARCs](/docs/ARCmanager-manual/03_view_ARCs.html)
-- [Create new ARCs](/docs/ARCmanager-manual/04_create_ARCs.html)
-- [Add new studies and assays](/docs/ARCmanager-manual/05_studies_assays.html)
-- [Upload files](/docs/ARCmanager-manual/05_uploading_files.html)
-- [Add metadata to your ARCs](/docs/ARCmanager-manual/06_adding_metadata.html)
+- [What is the ARCmanager?](./01_intro.html)
+- [Connect to your DataHUB](./02_login.html)
+- [View ARCs](./03_view_ARCs.html)
+- [Create new ARCs](./04_create_ARCs.html)
+- [Add new studies and assays](./05_studies_assays.html)
+- [Upload files](./05_uploading_files.html)
+- [Add metadata to your ARCs](./06_adding_metadata.html)
 
 ---
 

--- a/src/docs/ARCmanager-manual/01_intro.md
+++ b/src/docs/ARCmanager-manual/01_intro.md
@@ -13,4 +13,4 @@ date: 2024-01-08
 
 The ARCmanager is a web service that allows DataPLANT users to create and modify ARCs in a web browser environment. Edits done with the ARCmanager will be directly applied to the copy of your ARC on the respective DataHUB.
 
-While the [ARC Commander](/docs/ArcCommanderManual/index.html) provides a command line interface (CLI) to create and modify ARCs, and the [ARCitect](/docs/ARCitect-Manual/index.html) is a desktop application to perform similar tasks with a graphical user interface (GUI), the ARCmanager provides a web interface for editing ARCs without the necessity to install any software on your computer.
+While the [ARC Commander](./../ArcCommanderManual/index.html) provides a command line interface (CLI) to create and modify ARCs, and the [ARCitect](./../ARCitect-Manual/index.html) is a desktop application to perform similar tasks with a graphical user interface (GUI), the ARCmanager provides a web interface for editing ARCs without the necessity to install any software on your computer.

--- a/src/docs/ARCmanager-manual/05_studies_assays.md
+++ b/src/docs/ARCmanager-manual/05_studies_assays.md
@@ -11,7 +11,7 @@ status: published
 date: 2024-06-13
 ---
 
-According to the  [ISA Metadata Model](/docs/ArcCommanderManual/arc_isa.html), each **study** is connected to an **Investigation** and can contain several **assays**. Follow the steps below to learn how to create new studies and assays and how to register them in the _isa.investigation.xlsx_ file.  
+According to the  [ISA Metadata Model](./../guides/index-AnnotateDataInYourARC.html), each **study** is connected to an **Investigation** and can contain several **assays**. Follow the steps below to learn how to create new studies and assays and how to register them in the _isa.investigation.xlsx_ file.  
 
 1. Navigate to the **studies** folder of your ARC. Then, click on the green `ADD` button to create a new study. A new input field will appear in which you need to specify a name for the study. Avoid whitespace characters when choosing a name for the study.
 

--- a/src/docs/ARCmanager-manual/06_adding_metadata.md
+++ b/src/docs/ARCmanager-manual/06_adding_metadata.md
@@ -13,18 +13,12 @@ date: 2024-06-13
 
 Two different types of metadata are stored in ISA files: administrative and experimental metadata. Administrative metadata covers IDs, descriptions, contact details, connected publications and more, while experimental metadata is describing experimental procedures and similar processes. ISA files are normally stored in an Excel format (.xlsx) and need to adhere to the [ISA-XLSX specification](https://github.com/nfdi4plants/ARC-specification/blob/main/ISA-XLSX.md).
 
-A typical ISA file has the administrative metadata recorded in the first sheet of the Excel file (top-level metadata sheet). In addition, every _isa.study.xlsx_ and _isa.assay.xlsx_ file should have at least one more sheet where the experimental metadata is annotated (annotation table sheets), that is maintained through SWATE. Both types of metadata can be edited with the ARCmanager. You can find more information about ISA file types and metadata sheets in the corresponding [knowledgebase article](/docs/guides/isa_FileTypes.html) and the [ISA-XLSX specification](https://github.com/nfdi4plants/ARC-specification/blob/main/ISA-XLSX.md).
+A typical ISA file has the administrative metadata recorded in the first sheet of the Excel file (top-level metadata sheet). In addition, every _isa.study.xlsx_ and _isa.assay.xlsx_ file should have at least one more sheet where the experimental metadata is annotated (annotation table sheets), that is maintained through Swate. Both types of metadata can be edited with the ARCmanager. You can find more information about ISA file types and metadata sheets in the corresponding [knowledge base article](/docs/guides/isa_FileTypes.html) and the [ISA-XLSX specification](https://github.com/nfdi4plants/ARC-specification/blob/main/ISA-XLSX.md).
 
 #### Contents:
 
-- [Administrative metadata (top-level metadata sheets)](#administrative-metadata-top-level-metadata-sheets)
-   * [Alternative view](#alternative-view) 
-- [Experimental metadata (annotation table sheets)](#experimental-metadata-annotation-table-sheets)
-   * [Add new annotation table sheets](#add-new-annotation-table-sheets)
-   * [Import annotation table templates](#import-annotation-table-templates)
-   * [Edit annotation table sheets](#edit-annotation-table-sheets)
-   * [Ontology term search](#ontology-term-search)
-   * [Adding new building blocks to annotation tables](#adding-new-building-blocks-to-annotation-tables)
+- [Administrative Metadata (top-level metadata sheets)](#administrative-metadata-top-level-metadata-sheets)
+- [Experimental Metadata (annotation table sheets)](#experimental-metadata-annotation-table-sheets)
 
 ### Administrative Metadata (top-level metadata sheets)
 

--- a/src/docs/ARCmanager-manual/06_adding_metadata.md
+++ b/src/docs/ARCmanager-manual/06_adding_metadata.md
@@ -17,8 +17,14 @@ A typical ISA file has the administrative metadata recorded in the first sheet o
 
 #### Contents:
 
-- [Administrative Metadata (top-level metadata sheets)](#administrative-metadata-top-level-metadata-sheets)
-- [Experimental Metadata (annotation table sheets)](#experimental-metadata-annotation-table-sheets)
+- [Administrative metadata (top-level metadata sheets)](#administrative-metadata-top-level-metadata-sheets)
+   * [Alternative view](#alternative-view) 
+- [Experimental metadata (annotation table sheets)](#experimental-metadata-annotation-table-sheets)
+   * [Add new annotation table sheets](#add-new-annotation-table-sheets)
+   * [Import annotation table templates](#import-annotation-table-templates)
+   * [Edit annotation table sheets](#edit-annotation-table-sheets)
+   * [Ontology term search](#ontology-term-search)
+   * [Adding new building blocks to annotation tables](#adding-new-building-blocks-to-annotation-tables)
 
 ### Administrative Metadata (top-level metadata sheets)
 


### PR DESCRIPTION
Not sure why, but links with [](/doc/...) work fine in preview but not in production. 
Replaced with relative links. 