### PR TITLE
Small fix to swate in excel guide

### DIFF
--- a/src/content/docs/guides/annotate-in-excel.mdx
+++ b/src/content/docs/guides/annotate-in-excel.mdx
@@ -19,10 +19,11 @@ The excel-add-in will soon be published in the official [Microsoft Excel-Add-Ins
 ## Installation
 Currently, we recommend the installation using the [excel-browser version provided by microsoft](https://excel.cloud.microsoft/?wdOrigin=MARKETING.FREE.GO-TO-EXCEL) because the set up is much easier than with a local excel version.
 
+Start by downloading the Swate [Manifest File](https://github.com/nfdi4plants/Swate/blob/main/build/manifest.production.xml). 
+
 <Tabs syncKey="swateHost">
 <TabItem label="Browser">
 
-Start by downloading the Swate [Manifest File](https://github.com/nfdi4plants/Swate/blob/main/build/manifest.production.xml). 
 
 <Steps>
 
@@ -47,7 +48,7 @@ Start by downloading the Swate [Manifest File](https://github.com/nfdi4plants/Sw
 
 <Steps>
 
-1. Follow the Microsoft official documentation for sideloading add ins [Excel-Add-Ins](https://learn.microsoft.com/en-us/office/dev/add-ins/testing/test-debug-office-add-ins#sideload-an-office-add-in-for-testing).
+1. After downloading the manifest file, follow the Microsoft official documentation for sideloading add ins [Excel-Add-Ins](https://learn.microsoft.com/en-us/office/dev/add-ins/testing/test-debug-office-add-ins#sideload-an-office-add-in-for-testing).
 2. When the installation was successful, the icon of [Swate](https://nfdi4plants.github.io/nfdi4plants.knowledgebase/swate/), the Excel-Add-In for annotating data, should be available in the data tab.
 3. When you click on the icon the sidebar of swate should appear. Its size is adaptable and when it is big enough, the quick icons of the navbar are visible.
 4. When everything was successful, it should look similar to this:


### PR DESCRIPTION
`"Download Manifest File"` step was only part of installation guide for `Browser`, but should be above, also being a dependency for `Excel`