### PR TITLE
Update the installation page in quick start guide

### DIFF
--- a/src/content/docs/arc-commander/arc-commander-quick-start.mdx
+++ b/src/content/docs/arc-commander/arc-commander-quick-start.mdx
@@ -40,7 +40,7 @@ Before using the ARC commander, please install Git, Git-LFS and ARC Commander an
   2. 
       <details>
         <summary>Install ARC Commander</summary>
-        <InstallationGit />
+        <InstallationARCCommander />
       </details>
 
   3. 


### PR DESCRIPTION
Update with the right ARCCommander installation page which was addressed to Git installation.

# Thank you for contributing to the DataPLANT Knowledge Base :rocket:

## Please make sure that

- [ ] your pull request has a **good title**,
- [ ] you add a short description below to summarize your changes,
- [ ] the contents and images you add, are allowed to be shared publicly and - if applicable - reference the source properly,
- [ ] you read the [contribution guide](https://github.com/nfdi4plants/nfdi4plants.knowledgebase/blob/main/CONTRIBUTING.md),
- [ ] you tested your changes locally via `npm run dev` and `npm run build`

If you are unsure, you can also label your PR as draft.

## Description
In quick start, after clicking the ARCCommander installation, the link directed the user to the Git installation page. The address has been corrected. 