### PR TITLE
Update Git installation info

### DIFF
--- a/src/content/docs/git/git-check.mdx
+++ b/src/content/docs/git/git-check.mdx
@@ -24,7 +24,7 @@ To check, that <a href="https://git-scm.com/downloads" target="_blank">Git</a> a
     ```
 
     :::tip
-    Recommended Git version ≥ 2.32.0
+    Recommended Git version ≥ 2.32.0 and < 2.52
     :::
 
 3. Check the installed Git LFS version via 

--- a/src/content/docs/git/git-installation.mdx
+++ b/src/content/docs/git/git-installation.mdx
@@ -7,6 +7,8 @@ authors:
 
 Before using [ARCitect](/nfdi4plants.knowledgebase/arcitect) (except for Windows) or [ARC Commander](/nfdi4plants.knowledgebase/arc-commander), **Git** and **Git LFS** must be installed.
 
+:exclamation: **Git** versions ≥ 2.52 are not compatible and should not be installed. The highest compatible version is 2.51, which is recommended for installation.
+
 ## Download and install Git and Git LFS
 
 import GitDownload from 'git-download.mdx'


### PR DESCRIPTION
Updating `git` above v2.51 will break `git-lfs` and related operations because git changed parsing of its `-c` parameter with version 2.52. 
It is related to this issue: https://jira.atlassian.com/browse/BAM-26262 . 

I changed two files regarding the `git` installation to give users a warning to not install/update to this particular `git` version.